### PR TITLE
Add new like

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import './style.css';
 import displayCard from './modules/displayCard.js';
+import initId from './modules/init.js';
 
 // Display all items
 const displayItems = async (artistId = '271256') => {
@@ -12,5 +13,5 @@ const displayItems = async (artistId = '271256') => {
       element.collectionCensoredName, element.artistName);
   }
 };
-
+initId();
 displayItems();

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,7 @@ const displayItems = async (artistId = '271256') => {
   const obj = await response.json();
   for (let index = 1; index < obj.results.length; index += 1) {
     const element = obj.results[index];
-    displayCard(container, element.artworkUrl100,
-      element.collectionCensoredName, element.artistName);
+    displayCard(container, element.artworkUrl100, element.artistName);
   }
 };
 initId();

--- a/src/modules/displayCard.js
+++ b/src/modules/displayCard.js
@@ -1,8 +1,7 @@
-import setLike from "./likeButton.js";
+import setLike from './likeButton.js';
 
 // Display single card/item
-const displayCard = (container, albumImg = 'unknown', albumName = 'no-name' , artistName="Unknow" , likes = 0) => {
-  artistName ="drake";
+const displayCard = (container, albumImg = 'unknown', albumName = 'no-name', likes = 0) => {
   const likesCounter = likes;
   const div = document.createElement('div');
   const img = document.createElement('img');
@@ -19,7 +18,7 @@ const displayCard = (container, albumImg = 'unknown', albumName = 'no-name' , ar
   likeIcon.setAttribute('data-likes', likesCounter);
   likeIcon.setAttribute('data-itemId', itemId);
   descriptionText.setAttribute('data-cardid', itemId);
-  descriptionText.textContent = likeIcon.dataset.likes +' likes';
+  descriptionText.textContent = `${likeIcon.dataset.likes} likes`;
   likeIcon.setAttribute('src', 'https://cdn-icons-png.flaticon.com/512/126/126473.png');
   likeIcon.classList.add('icon-size');
   likesContainer.classList.add('description-container');

--- a/src/modules/displayCard.js
+++ b/src/modules/displayCard.js
@@ -1,8 +1,9 @@
 import setLike from "./likeButton.js";
 
 // Display single card/item
-const displayCard = (container, albumImg = 'unknown', albumName = 'no-name') => {
-  const likesCounter = 0;
+const displayCard = (container, albumImg = 'unknown', albumName = 'no-name' , artistName="Unknow" , likes = 0) => {
+  artistName ="drake";
+  const likesCounter = likes;
   const div = document.createElement('div');
   const img = document.createElement('img');
   const i = document.createElement('i');
@@ -17,6 +18,7 @@ const displayCard = (container, albumImg = 'unknown', albumName = 'no-name') => 
 
   likeIcon.setAttribute('data-likes', likesCounter);
   likeIcon.setAttribute('data-itemId', itemId);
+  descriptionText.setAttribute('data-cardid', itemId);
   descriptionText.textContent = likeIcon.dataset.likes +' likes';
   likeIcon.setAttribute('src', 'https://cdn-icons-png.flaticon.com/512/126/126473.png');
   likeIcon.classList.add('icon-size');

--- a/src/modules/displayCard.js
+++ b/src/modules/displayCard.js
@@ -9,7 +9,7 @@ const displayCard = (container, albumImg = 'unknown', albumName = 'no-name') => 
   const descriptionText = document.createElement('p');
   const commentsButton = document.createElement('button');
   const reservationsButton = document.createElement('button');
-
+  
   descriptionText.textContent = '5 likes';
   likeIcon.setAttribute('src', 'https://cdn-icons-png.flaticon.com/512/126/126473.png');
   likeIcon.classList.add('icon-size');

--- a/src/modules/displayCard.js
+++ b/src/modules/displayCard.js
@@ -1,7 +1,11 @@
+import setLike from "./likeButton.js";
+
 // Display single card/item
 const displayCard = (container, albumImg = 'unknown', albumName = 'no-name') => {
+  const likesCounter = 0;
   const div = document.createElement('div');
   const img = document.createElement('img');
+  const i = document.createElement('i');
   const h3 = document.createElement('h3');
   const titleContainer = document.createElement('div');
   const likeIcon = document.createElement('img');
@@ -9,8 +13,11 @@ const displayCard = (container, albumImg = 'unknown', albumName = 'no-name') => 
   const descriptionText = document.createElement('p');
   const commentsButton = document.createElement('button');
   const reservationsButton = document.createElement('button');
-  
-  descriptionText.textContent = '5 likes';
+  const itemId = document.querySelectorAll('#section > div').length;
+
+  likeIcon.setAttribute('data-likes', likesCounter);
+  likeIcon.setAttribute('data-itemId', itemId);
+  descriptionText.textContent = likeIcon.dataset.likes +' likes';
   likeIcon.setAttribute('src', 'https://cdn-icons-png.flaticon.com/512/126/126473.png');
   likeIcon.classList.add('icon-size');
   likesContainer.classList.add('description-container');
@@ -22,8 +29,10 @@ const displayCard = (container, albumImg = 'unknown', albumName = 'no-name') => 
   reservationsButton.textContent = 'Reservation';
   div.classList.add('items-container');
   titleContainer.classList.add('title-like');
+  i.addEventListener('click', setLike);
 
-  likesContainer.append(likeIcon, descriptionText);
+  likesContainer.append(i, descriptionText);
+  i.append(likeIcon);
   titleContainer.append(h3, likesContainer);
   div.append(img, titleContainer, commentsButton, reservationsButton);
   container.append(div);

--- a/src/modules/init.js
+++ b/src/modules/init.js
@@ -1,0 +1,17 @@
+/* Init App id */
+// Check for an existing App id, if there isn't create one
+
+const initId = async () => {
+  if (localStorage.getItem('appId') === null) {
+    const response = await fetch('https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/', {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json; charset=UTF-8',
+      },
+    });
+    const id = await response.text();
+    localStorage.setItem('appId', JSON.stringify(id));
+  }
+}
+
+export default initId;

--- a/src/modules/init.js
+++ b/src/modules/init.js
@@ -12,6 +12,6 @@ const initId = async () => {
     const id = await response.text();
     localStorage.setItem('appId', JSON.stringify(id));
   }
-}
+};
 
 export default initId;

--- a/src/modules/likeButton.js
+++ b/src/modules/likeButton.js
@@ -1,0 +1,3 @@
+const manageLikes = () => {
+  
+}

--- a/src/modules/likeButton.js
+++ b/src/modules/likeButton.js
@@ -1,4 +1,4 @@
-import updateLikeCounter from "./updateLikeCounter.js";
+import updateLikeCounter from './updateLikeCounter.js';
 
 // Add like to item using Involvement API
 async function setLike() {
@@ -7,16 +7,15 @@ async function setLike() {
   const cardId = likeIcon.dataset.itemid;
   const appId = JSON.parse(localStorage.getItem('appId'));
 
-    const response = await fetch(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${appId}/likes/`,{
-    method:'POST',
-    body:JSON.stringify({
-      "item_id": `${cardId}`
+  await fetch(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${appId}/likes/`, {
+    method: 'POST',
+    body: JSON.stringify({
+      item_id: `${cardId}`,
     }),
     headers: {
-        'Content-type': 'application/json; charset=UTF-8',
-      },
-    });
-    console.log(response);
+      'Content-type': 'application/json; charset=UTF-8',
+    },
+  });
   likeIcon.setAttribute('data-likes', likesNumber = Number(likesNumber) + 1);
   updateLikeCounter(cardId, likesNumber);
 }

--- a/src/modules/likeButton.js
+++ b/src/modules/likeButton.js
@@ -1,3 +1,21 @@
-const manageLikes = () => {
-  
+// Manage all interactions when like icon is clicked
+async function setLike() {
+  const likeIcon = this.firstChild;
+  const likesNumber = likeIcon.dataset.likes;
+  const cardId = likeIcon.dataset.itemid;
+  const appId = JSON.parse(localStorage.getItem('appId'));
+  if (likesNumber == 0) { // If clicked first time
+    const response = await fetch(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${appId}/likes/`,{
+    method:'POST',
+    body:JSON.stringify({
+      "item_id": `${cardId}`
+    }),
+    headers: {
+        'Content-type': 'application/json; charset=UTF-8',
+      },
+    });
+    console.log(response);
+  }
 }
+
+export default setLike;

--- a/src/modules/likeButton.js
+++ b/src/modules/likeButton.js
@@ -1,10 +1,12 @@
-// Manage all interactions when like icon is clicked
+import updateLikeCounter from "./updateLikeCounter.js";
+
+// Add like to item using Involvement API
 async function setLike() {
   const likeIcon = this.firstChild;
-  const likesNumber = likeIcon.dataset.likes;
+  let likesNumber = likeIcon.dataset.likes;
   const cardId = likeIcon.dataset.itemid;
   const appId = JSON.parse(localStorage.getItem('appId'));
-  if (likesNumber == 0) { // If clicked first time
+
     const response = await fetch(`https://us-central1-involvement-api.cloudfunctions.net/capstoneApi/apps/${appId}/likes/`,{
     method:'POST',
     body:JSON.stringify({
@@ -15,7 +17,8 @@ async function setLike() {
       },
     });
     console.log(response);
-  }
+  likeIcon.setAttribute('data-likes', likesNumber = Number(likesNumber) + 1);
+  updateLikeCounter(cardId, likesNumber);
 }
 
 export default setLike;

--- a/src/modules/updateLikeCounter.js
+++ b/src/modules/updateLikeCounter.js
@@ -1,6 +1,6 @@
 const updateLikeCounter = (cardId, likes) => {
   const pElement = document.querySelector(`[data-cardid="${cardId}"]`);
-  pElement.textContent = likes + ' likes';
+  pElement.textContent = `${likes} likes`;
 };
 
 export default updateLikeCounter;

--- a/src/modules/updateLikeCounter.js
+++ b/src/modules/updateLikeCounter.js
@@ -1,0 +1,6 @@
+const updateLikeCounter = (cardId, likes) => {
+  const pElement = document.querySelector(`[data-cardid="${cardId}"]`);
+  pElement.textContent = likes + ' likes';
+};
+
+export default updateLikeCounter;

--- a/src/style.css
+++ b/src/style.css
@@ -33,6 +33,7 @@ footer {
 img {
   width: 70%;
   align-self: center;
+  cursor: pointer;
 }
 
 #section {


### PR DESCRIPTION
When the user clicks on the like button of an item (on Homepage), the interaction is recorded in the Involvement API and the screen is updated:
1. [Add initId module to manage app id creation with Involvement API](https://github.com/idungstanley/API-based-webAPP/commit/edf5f5c34cb57f909777c1bb2d50677eb89f5793)
2.  [Add setLike to set the items likes when user click like button](https://github.com/idungstanley/API-based-webAPP/commit/45add9e6ac568946052d52f8d12d0d6305065507)
3. [Refresh like counter on screen when users likes the card](https://github.com/idungstanley/API-based-webAPP/commit/05689489003b67ad427d2d92c444a236ac508f76)
4. Minor Style and html structure changes.
5. [Solve linters](https://github.com/idungstanley/API-based-webAPP/commit/6c12f24a6d01788ed14ef0f7eda04d3633a711ef)